### PR TITLE
Add license metadata to package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "configcat-publicapi-node-client",
     "version": "3.2.2",
     "description": "NodeJS client for configcat-publicapi-node-client",
-        "license": "MIT",
+    "license": "MIT",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "configcat-publicapi-node-client",
     "version": "3.2.2",
     "description": "NodeJS client for configcat-publicapi-node-client",
-    "license": "MIT",
+"license": "MIT",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "configcat-publicapi-node-client",
     "version": "3.2.2",
     "description": "NodeJS client for configcat-publicapi-node-client",
+        "license": "MIT",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {


### PR DESCRIPTION
### Describe the purpose of your pull request
Adds MIT license metadata to package.json, matching the repository LICENSE file and making the published package metadata clearer for npm consumers and license/compliance scanners.

### Related issues (only if applicable)
None.

### How to test? (only if applicable)
Metadata-only change. I verified the edited package.json parses as JSON and resolves license to MIT.

### Security (only if applicable)
No runtime or security-sensitive code changed.

### Requirement checklist (only if applicable)
- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
